### PR TITLE
Fix invalid JSON in FHE Cloud Service REST client notebook

### DIFF
--- a/HE4Cloud/Notebooks/FHE_Cloud_Service/FHE_Cloud_Service_Rest_Client.ipynb
+++ b/HE4Cloud/Notebooks/FHE_Cloud_Service/FHE_Cloud_Service_Rest_Client.ipynb
@@ -379,7 +379,7 @@
      "output_type": "stream",
      "text": [
       "**** POST https://he4cloud.com/api/v0.1/7ff9e7d6-f79c-4b1f-8e90-97ee048d4e13/my_lr_fraud_model/v2/upload/evaluation_key_url\n",
-      "Response code: 200 message: https://7ff9e7d6-f79c-4b1f-8e90-97ee048d4e13.s3.amazonaws.com..,
+      "Response code: 200 message: https://7ff9e7d6-f79c-4b1f-8e90-97ee048d4e13.s3.amazonaws.com/UF_7ff9e7d6-f79c-4b1f-8e90-97ee048d4e13_my_lr_fraud_model_v2_c44a6f49-69ce-4376-8575-695cd82d9358_eva.key?AWSAccessKeyId=EXAMPLE_KEY...\n",
       "**** PUT b'https://7ff9e7d6-f79c-4b1f-8e90-97ee048d4e13.s3.amazonaws.com/UF_7ff9e7d6-f79c-4b1f-8e90-97ee048d4e13_my_lr_fraud_model_v2_c44a6f49-69ce-4376-8575-695cd82d9358_eva.key...'\n",
       "Response code: 200 message: \n",
       "<< Evaluation Key Uploaded Successfully\n"


### PR DESCRIPTION
## Problem
`HE4Cloud/Notebooks/FHE_Cloud_Service/FHE_Cloud_Service_Rest_Client.ipynb` fails to render on GitHub with an **invalid JSON** error.
